### PR TITLE
refactor to UnifiedJedis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,49 @@
+# 0.2.0
+
+* full refactor to support [UnifiedJedis](https://javadoc.io/static/redis.clients/jedis/5.0.0-beta2/redis/clients/jedis/UnifiedJedis.html)
+
+which is a stepping stone to JedisCluster, JedisPooled, JedisSentineled, JedisSharding
+
+a few braking changes (hence the minor version bump):
+
+* connecting / disconnecting
+
+pre "`0.2.x`":
+```clojure
+=> (def conn (redis/create-pool))
+=> (redis/close-pool conn)
+```
+
+`0.2.x` and later:
+
+```clojure
+=> (def conn (redis/connect))
+=> (redis/disconnect conn)
+```
+
+* configuration params
+
+some renames, some addtions, some regroupping:
+
+```clojure
+{:nodes                                  ;; [{:host "1.1.1.1" :port 6379} {:host "2.2.2.2" :port 6380}]
+ :to                                     ;; :cluster, :sentinel
+ :connection-timeout socket-timeout
+ :max-attempts
+ :username password
+ :database-index
+ :ssl?
+ :client-name
+ :master-name
+ :sentinel-client-config                 ;; if not provided a default config will be created if sentinel is used
+ :pool-size pool-max-wait pool-max-idle}
+```
+
+* pipelines
+
+they are currently on Jedis and will have to be ported to UnifiedJedis
+in this version they won't work
+
 # 0.1.4809
 
 * add params to `set` ([what params](https://redis.io/commands/set/)?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ which is a stepping stone to JedisCluster, JedisPooled, JedisSentineled, JedisSh
 
 a few braking changes (hence the minor version bump):
 
-* connecting / disconnecting
+### connecting / disconnecting
 
-pre "`0.2.x`":
+pre `0.2.x`:
 ```clojure
 => (def conn (redis/create-pool))
 => (redis/close-pool conn)
@@ -21,7 +21,7 @@ pre "`0.2.x`":
 => (redis/disconnect conn)
 ```
 
-* configuration params
+### configuration params
 
 some renames, some addtions, some regroupping:
 
@@ -39,9 +39,9 @@ some renames, some addtions, some regroupping:
  :pool-size pool-max-wait pool-max-idle}
 ```
 
-* pipelines
+### pipelines
 
-they are currently on Jedis and will have to be ported to UnifiedJedis
+they are currently on Jedis and will have to be ported to UnifiedJedis<br/>
 in this version they won't work
 
 # 0.1.4809

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.2.0
 
-* full refactor to support [UnifiedJedis](https://javadoc.io/static/redis.clients/jedis/5.0.0-beta2/redis/clients/jedis/UnifiedJedis.html)
+## full refactor to support [UnifiedJedis](https://javadoc.io/static/redis.clients/jedis/5.0.0-beta2/redis/clients/jedis/UnifiedJedis.html)
 
 which is a stepping stone to JedisCluster, JedisPooled, JedisSentineled, JedisSharding
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Let's try it out:
 ;;  :idle-resources 0}
 ```
 
-in order to connect to a different host, port, with a different number of threads, password, etc. `create-pool` takes a config:
+in order to connect to a different host, port, with a different number of threads, password, etc. `connect` takes a config:
 
 ```clojure
 => (def conn (redis/connect {:nodes [{:host "dotkam.com"
@@ -97,9 +97,9 @@ closing the pool:
 
 in order to connect to [Redis Sentinel](https://redis.io/docs/management/sentinel/) a few things need to be provided to obiwan:
 
-* "`:to`" key in params should say "`:sentinel`
-* "`:master-name`" since Redis does "[SENTINEL get-master-addr-by-name mymaster](https://redis.io/docs/management/sentinel/#obtaining-the-address-of-the-current-master)" from a client to lookup a master node
-* "`:nodes`" in a form of a collection of "`{:host :port}`" maps
+* `:to` key in params should say `:sentinel`
+* `:master-name` since Redis client does "[SENTINEL get-master-addr-by-name mymaster](https://redis.io/docs/management/sentinel/#obtaining-the-address-of-the-current-master)" to lookup a master node
+* `:nodes` in a form of a collection of `{:host :port}` maps
 
 example:
 
@@ -114,8 +114,8 @@ example:
 
 in order to connect to a [Redis Cluster](https://redis.io/docs/management/scaling/) a few things need to be provided to obiwan:
 
-* "`:to`" key in params should say "`:cluster`
-* "`:nodes`" in a form of a collection of "`{:host :port}`" maps
+* `:to` key in params should say `:cluster`
+* `:nodes` in a form of a collection of `{:host :port}` maps
 
 example:
 

--- a/README.md
+++ b/README.md
@@ -694,15 +694,30 @@ this is usefult to experiment with various redis commands to see what they retur
 ```
 
 ```clojure
-=> (redis/say conn "PING")
+=> (redis/say conn "DBSIZE")
+;; 42
+```
+
+passing arguments:
+
+```clojure
+=> (redis/say conn "COMMAND" {:args "COUNT"})
+;; 264
+```
+
+parsing replies with `:parse` function:
+
+```clojure
+=> (redis/say conn "PING" {:parse t/bytes->str})
 ;; "PONG"
 
-=> (redis/say conn "ECHO" {:args "HAYA!"})
+=> (redis/say conn "ECHO" {:args "HAYA!"
+                           :parse t/bytes->str})
 ;; "HAYA!"
 
 ```
 ```clojure
-=> (print (redis/say conn "INFO"))
+=> (print (redis/say conn "INFO" {:parse t/bytes->str}))
 
 ;; # Server
 ;; redis_version:6.2.5
@@ -715,18 +730,6 @@ this is usefult to experiment with various redis commands to see what they retur
 ;; ...
 ;; # Modules
 ;; module:name=search,ver=999999,api=1,filters=0,usedby=[],using=[],options=[]
-```
-
-parsing replies with `:expect` function:
-
-```clojure
-=> (redis/say conn "COMMAND" {:args "COUNT"
-                              :expect t/integer-reply})
-;; 264
-```
-```clojure
-=> (redis/say conn "DBSIZE" {:expect t/integer-reply})
-;; 42
 ```
 
 ## run/add tests

--- a/build.clj
+++ b/build.clj
@@ -8,7 +8,7 @@
 
 (defonce project
   (let [lib        'com.tolitius/obiwan
-        version    "0.1.4809"
+        version    "0.2.0"
         target-dir "target"]
     {:lib lib
      :description "redis clojure client based on jedis"

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
 
  :aliases {:dev {:extra-paths ["dev" "dev-resources"]
                  :extra-deps {metosin/jsonista {:mvn/version "0.3.3"}
-                              tolitius/yang {:mvn/version "0.1.29"}
+                              tolitius/yang {:mvn/version "0.1.37"}
                               io.github.clojure/tools.build {:git/sha "6736c83"
                                                              :git/tag "v0.1.9"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
 
- :deps {redis.clients/jedis {:mvn/version "4.2.0"}}
+ :deps {redis.clients/jedis {:mvn/version "4.4.3"}}
 
  :aliases {:dev {:extra-paths ["dev" "dev-resources"]
                  :extra-deps {metosin/jsonista {:mvn/version "0.3.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
 
- :deps {redis.clients/jedis {:mvn/version "4.4.3"}}
+ :deps {redis.clients/jedis {:mvn/version "5.0.0-beta2"}}
 
  :aliases {:dev {:extra-paths ["dev" "dev-resources"]
                  :extra-deps {metosin/jsonista {:mvn/version "0.3.3"}

--- a/src/obiwan/commands.clj
+++ b/src/obiwan/commands.clj
@@ -23,10 +23,16 @@
 (defn hset [h m]
   #(.hset % h m))
 
-(defn hmget [h fs]
+(defn hmget [redis h fs]
+  (.hmget redis h (into-array String fs)))
+
+(defn hmset [redis h m]
+  (.hmset redis h m))
+
+#_(defn hmget [h fs]
   #(.hmget % h (into-array String fs)))
 
-(defn hmset [h m]
+#_(defn hmset [h m]
   #(.hmset % h m))
 
 (defn hgetall [h]

--- a/src/obiwan/commands.clj
+++ b/src/obiwan/commands.clj
@@ -1,74 +1,12 @@
 (ns obiwan.commands
-  (:refer-clojure :exclude [get set type keys])
+  (:refer-clojure :exclude [get])
   (:require [obiwan.tools :as t])
   (:import [redis.clients.jedis.params SetParams]))
 
-;; wrap Java methods to make them composable
+;; TODO: add params for all commands
+;;       explicit is good, no macros
 
-;; check whether creating a function every time in (op redis #(this)) affects performance / GC collections
-;; only _iff_ it is of any significance precreate these
-;;      no matter the solution the public redis functions should remain _composable_
-;;      but.. pipelining commands should solve most if not all
-
-;; these command functions are decoupled from redis connection to enable pipeling
-;; i.e. to build command functions at runtime and then be passed into a pipeline
-
-;; TODO: add an "options" map
-
-;; hash
-
-(defn hget [h f]
-  #(.hget % h f))
-
-(defn hset [h m]
-  #(.hset % h m))
-
-(defn hmget [redis h fs]
-  (.hmget redis h (into-array String fs)))
-
-(defn hmset [redis h m]
-  (.hmset redis h m))
-
-#_(defn hmget [h fs]
-  #(.hmget % h (into-array String fs)))
-
-#_(defn hmset [h m]
-  #(.hmset % h m))
-
-(defn hgetall [h]
-  #(.hgetAll % h))
-
-(defn hdel [h vs]
-  #(.hdel % h (into-array String vs)))
-
-;; sorted set
-
-(defn zadd [k m]
-  #(.zadd % k m))
-
-(defn zrange [k zmin zmax]
-  #(.zrange % k zmin zmax))
-
-;; set
-
-(defn smembers [s]
-  #(.smembers % s))
-
-(defn scard [s]
-  #(.scard % s))
-
-(defn sismember [s v]
-  #(.sismember % s v))
-
-(defn sadd [s vs]
-  #(.sadd % s (into-array
-                String vs)))
-
-(defn srem [s vs]
-  #(.srem % s (into-array
-                String vs)))
-
-;; basic operations
+(defonce MODULE (t/make-protocol-command "MODULE"))
 
 (defn ->set-params [{:keys [xx nx px ex exat pxat keepttl get]}]
   (cond-> (SetParams/setParams)
@@ -80,51 +18,3 @@
     pxat (.pxAt pxat)
     keepttl (.keepttl)
     get (.get)))
-
-(defn set
-  ([k v]
-   #(.set % k v))
-  ([k v params]
-   (let [ps (->set-params params)]
-     #(.set % k v ps))))
-
-(defn get [k]
-  #(.get % k))
-
-(defn mset [m]
-  #(.mset % (t/m->array m)))
-
-(defn mget [ks]
-  #(.mget % (into-array ks)))
-
-(defn del [ks]
-  #(.del % (into-array ks)))
-
-(defn exists [vs]
-  #(.exists % (into-array vs)))
-
-(defn type [k]
-  #(.type % k))
-
-(defn keys [k]
-  #(.keys % k))
-
-(defn incr [k]
-  #(.incr % k))
-
-(defn incr-by [k v]
-  #(.incrBy % k v))
-
-(defn decr [k]
-  #(.decr % k))
-
-(defn decr-by [k v]
-  #(.decrBy % k v))
-
-;; ops
-
-(defn module-load [path]
-  #(.moduleLoad % path))
-
-(defn module-unload [mname]
-  #(.moduleLoad % mname))

--- a/src/obiwan/core.clj
+++ b/src/obiwan/core.clj
@@ -2,9 +2,11 @@
   (:refer-clojure :exclude [get set type keys])
   (:require [obiwan.commands :as c]
             [obiwan.tools :as t])
-  (:import [redis.clients.jedis Jedis
-                                Protocol
-                                JedisPool
+  (:import [redis.clients.jedis Protocol
+                                Pipeline
+                                HostAndPort
+                                UnifiedJedis
+                                JedisCluster
                                 JedisPooled
                                 JedisPoolConfig]
            [redis.clients.jedis.util Pool]
@@ -14,23 +16,18 @@
            [java.time Duration]
            [org.apache.commons.pool2.impl GenericObjectPool GenericObjectPoolConfig]))
 
-(defn new-conn [^Pool pool]
-  (.getResource pool))
-
-(defn op [pool f]
-  (with-open [^Jedis r (new-conn pool)]
-    (f r)))
-
-(defn create-pool
+(defn connect
   ([]
-   (create-pool {}))
+   (connect {}))
   ([{:keys [host port timeout
+            to
             username password
             database-index ssl?
             size
             max-wait max-idle]
      :or {host "127.0.0.1"
           port 6379
+          to :default
           timeout Protocol/DEFAULT_TIMEOUT
           database-index Protocol/DEFAULT_DATABASE
           ssl? false
@@ -42,27 +39,43 @@
                 (.setMaxTotal size)
                 (.setMaxIdle max-idle)
                 (.setMaxWaitMillis max-wait))]
-     (println (str "connecting to Redis " host ":" port ", timeout: " timeout ", config: "
-                   (dissoc opts :username :password)))
-     (JedisPooled. conf
-                  ^String host
-                  ^int port
-                  ^int timeout
-                  ^String username
-                  ^String password
-                  ^int database-index
-                  ^Boolean ssl?))))
+     (case to
+       :default (do (println (str "connecting to Redis " host ":" port ", timeout: " timeout ", config: "
+                                  (dissoc opts :username :password)))
+                    (JedisPooled. conf
+                                  ^String host
+                                  ^int port
+                                  ^int timeout
+                                  ^String username
+                                  ^String password
+                                  ^int database-index
+                                  ^Boolean ssl?))
+       :cluster (do (println (str "connecting to Redis cluster " host ":" port ", timeout: " timeout ", config: "
+                                  (dissoc opts :username :password)))
+                    (JedisCluster. conf
+                                   ^String host
+                                   ^int port
+                                   ^int timeout
+                                   ^String username
+                                   ^String password
+                                   ^int database-index
+                                   ^Boolean ssl?))
+       (throw (RuntimeException.
+                (str "\"" to "\" is an unknown source to connect to. supported are \":default\" and \":cluster\"")))))))
 
-(defn close-pool [redis]
+(defn disconnect [redis]
   (println "disconnecting from Redis")
   (-> redis
       .getPool
       .destroy)
-  :pool-closed)
+  :disconnected-from-redis)
 
-(defn connected? [pool]
+(declare say)
+
+(defn connected? [redis]
   (try
-    (op pool (fn [_] true))
+    (= "PONG"
+       (say redis "PING" {:parse t/bytes->str}))
     (catch JedisConnectionException ex
       (println ex)
       false)))
@@ -113,156 +126,118 @@
 (defn ^{:doc {:obiwan-doc
               "takes in a jedis connection pool, a hash name and a field name if present, returns a field name value"}}
   hget
-  ([h f] (c/hget h f))
-  ([^JedisPool redis h f]
-   (op redis (c/hget h f))))
+  ([^UnifiedJedis redis h f]
+   (.hget redis h f)))
 
-(defn hset
-  ([h m] (c/hset h m))
-  ([redis h m]
-   ((c/hset h m) redis)))
+(defn hset [^UnifiedJedis redis h m]
+   (.hset redis h m))
 
-(defn hmget
-  ([h fs] (c/hmget h fs))
-  ([^JedisPool redis h fs]
-   (into [] (c/hmget redis h fs))))
+(defn hmget [^UnifiedJedis redis h fs]
+  (->> (.hmget redis
+               h
+               (into-array String fs))
+       (into [])))
 
-(defn hmset
-  ([h m] (c/hmset h m))
-  ([redis h m]
-   (op redis (c/hmset h m))))
+(defn hgetall [^UnifiedJedis redis h]
+  (->> (.hgetAll redis h)
+       (into {})))
 
-(defn hgetall
-  ([h] (c/hgetall h))
-  ([^JedisPool redis h]
-   (into {} (op redis (c/hgetall h)))))
-
-(defn hdel
-  ([h vs] (c/hdel h vs))
-  ([redis h vs]
-   (op redis (c/hdel h vs))))
+(defn hdel [^UnifiedJedis redis h vs]
+  (.hdel redis h (into-array String vs)))
 
 ;; sorted set
 
-(defn zadd
-  ([k m] (c/zadd k m))
-  ([redis k m]
-   (op redis #(.zadd % k m))))
+(defn zadd [^UnifiedJedis redis k m]
+  (.zadd redis k m))
 
-(defn zrange
-  ([k zmin zmax] (c/zrange k zmin zmax))
-  ([redis k zmin zmax]
-   (op redis #(.zrange % k zmin zmax))))
+(defn zrange [^UnifiedJedis redis k zmin zmax]
+  (.zrange redis k zmin zmax))
 
 ;; set
 
-(defn smembers
-  ([s] (c/smembers s))
-  ([redis s]
-   (op redis (c/smembers s))))
+(defn smembers [^UnifiedJedis redis s]
+  (.smembers redis s))
 
-(defn scard
-  ([s] (c/scard s))
-  ([redis s]
-   (op redis (c/scard s))))
+(defn scard [^UnifiedJedis redis s]
+  (.scard redis s))
 
-(defn sismember
-  ([s v] (c/smembers s v))
-  ([redis s v]
-   (op redis (c/smembers s v))))
+(defn sismember [^UnifiedJedis redis s v]
+  (.sismember redis s v))
 
-(defn sadd
-  ([s vs] (c/sadd s vs))
-  ([redis s vs]
-   (op redis (c/sadd s vs))))
+(defn sadd [^UnifiedJedis redis s vs]
+  (.sadd redis s (into-array
+                   String vs)))
 
-(defn srem
-  ([s vs] (c/srem s vs))
-  ([redis s vs]
-   (op redis (c/srem s vs))))
+(defn srem [^UnifiedJedis redis s vs]
+  (.srem redis s (into-array
+                   String vs)))
 
 ;; basic operations
 
 (defn set
-  ([k v] (c/set k v))
-  ([redis k v]
-   (op redis (c/set k v)))
-  ([redis k v params]
-   (op redis (c/set k v params))))
+  ([^UnifiedJedis redis k v]
+   (.set redis k v))
+  ([^UnifiedJedis redis k v params]
+   (let [ps (c/->set-params params)]
+     (.set redis k v ps))))
 
-(defn get
-  ([k] (c/get k))
-  ([redis k]
-   (op redis (c/get k))))
+(defn get [^UnifiedJedis redis k]
+  (.get redis k))
 
-(defn mset
-  ([m] (c/mset m))
-  ([redis m]
-   (op redis (c/mset m))))
+(defn mset [^UnifiedJedis redis m]
+  (.mset redis (t/m->array m)))
 
-(defn mget
-  ([ks] (c/mget ks))
-  ([redis ks]
-   (op redis (c/mget ks))))
+(defn mget [^UnifiedJedis redis ks]
+  (.mget redis (into-array ks)))
 
-(defn del
-  ([ks] (c/del ks))
-  ([redis ks]
-   (op redis (c/del ks))))
+(defn del [^UnifiedJedis redis ks]
+  (.del redis (into-array ks)))
 
-(defn exists
-  ([vs] (c/exists vs))
-  ([redis vs]
-   (op redis (c/exists vs))))
+(defn exists [^UnifiedJedis redis vs]
+  (.exists redis (into-array vs)))
 
-(defn type
-  ([k] (c/type k))
-  ([redis k]
-   (op redis (c/type k))))
+(defn type [^UnifiedJedis redis k]
+  (.type redis k))
 
-(defn keys
-  ([k] (c/keys k))
-  ([redis k]
-   (op redis (c/keys k))))
+(defn keys [^UnifiedJedis redis k]
+  (.keys redis k))
 
-(defn incr
-  ([k] (c/incr k))
-  ([redis k]
-   (op redis (c/incr k))))
+(defn incr [^UnifiedJedis redis k]
+  (.incr redis k))
 
-(defn incr-by
-  ([k v] (c/incr-by k v))
-  ([redis k v]
-   (op redis (c/incr-by k v))))
+(defn incr-by [^UnifiedJedis redis k v]
+  (.incrBy redis k v))
 
-(defn decr
-  ([k] (decr k))
-  ([redis k]
-   (op redis (c/decr k))))
+(defn decr [^UnifiedJedis redis k]
+  (.decr redis k))
 
-(defn decr-by
-  ([k v] (c/decr-by k v))
-  ([redis k v]
-   (op redis (c/decr-by k v))))
+(defn decr-by [^UnifiedJedis redis k v]
+  (.decrBy redis k v))
 
 ;; ops
 
-(defn module-load
-  ([path]
-   (c/module-load path))
-  ([redis path]
-   (op redis (c/module-load path))))
+(defn module-load [^UnifiedJedis redis path]
+  (t/send-command redis
+                  c/MODULE
+                  (into-array String ["LOAD" path])))
 
-(defn module-unload
-  ([mname]
-   (c/module-unload mname))
-  ([redis mname]
-   (op redis (c/module-unload mname))))
+(defn module-unload [^UnifiedJedis redis mname]
+  (t/send-command redis
+                  c/MODULE
+                  (into-array String ["UNLOAD" mname])))
 
 ;; pipeline
 
-(defn make-pipeline [conn]
-  (.pipelined conn))
+(defn make-pipeline [^UnifiedJedis redis]
+  (cond
+    (instance? JedisPooled redis) (let [conn (-> redis
+                                                 .getPool
+                                                 .getResource)]
+                                    {:conn conn :pipe (Pipeline. conn)})
+    (instance? JedisCluster redis) (throw (RuntimeException.
+                                            "redis pipeline is not yet supported on the type JedisCluster"))
+    :else (throw (RuntimeException.
+                   (str "redis pipeline is not supported on the type \"" (class redis) "\"")))))
 
 (defn sync-pipeline [pipe]
   (.sync pipe))
@@ -270,14 +245,13 @@
 (defn realize-responses [rs]
   (mapv #(.get %) rs))
 
-(defn pipeline [redis commands]
-  (op redis
-      (fn [conn]
-        (let [pipe (make-pipeline conn)
-              rs (mapv #(% pipe)
+(defn pipeline [^UnifiedJedis redis commands]
+  (let [{:keys [conn pipe]} (make-pipeline redis)]
+    (try (let [rs (map #(% pipe)
                        commands)]
-          (sync-pipeline pipe)
-          (realize-responses rs)))))
+           (sync-pipeline pipe)
+           (realize-responses rs))
+         (finally (.close conn)))))
 
 ;; scaning things
 
@@ -290,7 +264,7 @@
   ([redis s cur]
    (sscan redis s cur {}))
   ([redis s cur params]
-   (let [^ScanResult rs (op redis #(.sscan % s cur (new-scan-params params)))
+   (let [^ScanResult rs (.sscan redis s cur (new-scan-params params))
          batch  (.getResult rs)
          cursor (.getCursor rs)]
      {:batch batch :cursor cursor :done? (.isCompleteIteration rs)})))

--- a/src/obiwan/search/command/aggregate.clj
+++ b/src/obiwan/search/command/aggregate.clj
@@ -140,17 +140,16 @@
 ;;       plus can be positioned anywhere in a query addiing a different meaning that depends on a position
 ;;       the actual query has to be a vector of maps vs. a map
 (defn aggregate-index [^JedisPool redis
-                       iname
-                       query
-                       opts]
+                                  iname
+                                  query
+                                  opts]
   (let [params (mapv opt->command opts)
         opts (->> params
                   (mapcat cmd/redisify)
                   (cons query)
                   (cons iname)
                   ; debug
-                  (into-array String))
-        send-search #(-> (t/send-command cmd/FT_AGGREGATE opts %)
-                         t/binary-multi-bulk-reply)]
-    (-> (oc/op redis send-search)
+                  (into-array String))]
+    (-> (t/send-command redis cmd/FT_AGGREGATE opts)
+        t/bytes->seq
         response->human)))

--- a/src/obiwan/search/command/create.clj
+++ b/src/obiwan/search/command/create.clj
@@ -126,7 +126,6 @@
                    (cmd/redisify-params fields)]
                   t/xs->str
                   t/tokenize
-                  (into-array String))
-        send-create #(-> (t/send-command cmd/FT_CREATE opts %)
-                         t/status-code-reply)]
-    (oc/op redis send-create)))
+                  (into-array String))]
+    (-> (t/send-command redis cmd/FT_CREATE opts)
+        t/bytes->str)))

--- a/src/obiwan/search/command/search.clj
+++ b/src/obiwan/search/command/search.clj
@@ -89,17 +89,16 @@
                                        "' search option is not (yet?) implemented for " opt)))))))
 
 (defn search-index [^JedisPool redis
-                     iname
-                     query
-                     opts]
+                               iname
+                               query
+                               opts]
   (let [params (mapv opt->command opts)
         opts (->> params
                   (mapcat cmd/redisify)
                   (cons query)
                   (cons iname)
                   ; debug
-                  (into-array String))
-        send-search #(-> (t/send-command cmd/FT_SEARCH opts %)
-                         t/binary-multi-bulk-reply)]
-    (-> (oc/op redis send-search)
+                  (into-array String))]
+    (-> (t/send-command redis cmd/FT_SEARCH opts)
+        t/bytes->seq
         response->human)))

--- a/src/obiwan/tools.clj
+++ b/src/obiwan/tools.clj
@@ -142,4 +142,3 @@
    (tokenize xs " "))
   ([xs separator]
    (s/split xs (re-pattern separator))))
-

--- a/src/obiwan/tools.clj
+++ b/src/obiwan/tools.clj
@@ -16,7 +16,7 @@
                (filterv #(and (= mname   (.getName %))
                               (= mparams (apply str (.getParameterTypes %)))))
                first)]
-    (println "calling " m ", with params:" mparams ", and args:" args)
+    #_(println "calling " m ", with params:" mparams ", and args:" args)
     (if (seq args)
       (. m (invoke obj (into-array Object args)))
       (. m (invoke obj (into-array Object []))))))

--- a/test/obiwan/test.clj
+++ b/test/obiwan/test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :as t :refer [deftest is]]
             [obiwan.test.tools :as tt]
             [obiwan.core :as redis]
+            [obiwan.tools :as ot]
             obiwan.search.core
             obiwan.test.search))
 
@@ -12,7 +13,8 @@
   (is (redis/connected? tt/conn)))
 
 (deftest should-ping-pong
-  (is (= "PONG" (redis/say tt/conn "PING"))))
+  (is (= "PONG" (redis/say tt/conn "PING"
+                           {:parse ot/bytes->str}))))
 
 (deftest should-set-and-get
   (let [k "foo"
@@ -49,13 +51,14 @@
     (is (= 3 (redis/hset tt/conn earth details)))
     (is (= details (redis/hgetall tt/conn earth)))))
 
-(deftest should-run-commands-in-pipeline
+;; TODO: test pipeline once the pipeline support for JedisPooled & JedisCluster is added
+#_(deftest should-run-commands-in-pipeline
   (let [numbers {"1" "one" "2" "two" "3" "three"}
         letters {"a" "ey" "b" "bee" "c" "cee"}
-        commands [(redis/hset "numbers" numbers)
-                  (redis/hset "letters" letters)
-                  (redis/hgetall "numbers")
-                  (redis/hgetall "letters")]]
+        commands [#(.hset % "numbers" numbers)
+                  #(.hset % "letters" letters)
+                  #(.hgetAll % "numbers")
+                  #(.hgetAll % "letters")]]
     (is (= [(count numbers)
             (count letters)
             numbers

--- a/test/obiwan/test/search.clj
+++ b/test/obiwan/test/search.clj
@@ -15,14 +15,14 @@
                      :schema [#:text{:name "nick" :sortable? true}
                               #:text{:name "age" :no-index? true}
                               #:numeric{:name "mass" :sortable? true}]})
-  (redis/hmset conn "solar:planet:earth"
-               {"nick" "the blue planet" "age" "4.543 billion years" "mass" "5974000000000000000000000"})
-  (redis/hmset conn "solar:planet:mars"
-               {"nick" "the red planet" "age" "4.603 billion years" "mass" "639000000000000000000000"})
-  (redis/hmset conn "solar:planet:pluto"
-               {"nick" "tombaugh regio" "age" "4.5 billion years" "mass" "13090000000000000000000"})
-  (redis/hmset conn "solar:planet:moon:charon"
-               {"planet" "pluto" "nick" "char" "age" "4.5 billion years" "mass" "1586000000000000000000"}))
+  (redis/hset conn "solar:planet:earth"
+              {"nick" "the blue planet" "age" "4.543 billion years" "mass" "5974000000000000000000000"})
+  (redis/hset conn "solar:planet:mars"
+              {"nick" "the red planet" "age" "4.603 billion years" "mass" "639000000000000000000000"})
+  (redis/hset conn "solar:planet:pluto"
+              {"nick" "tombaugh regio" "age" "4.5 billion years" "mass" "13090000000000000000000"})
+  (redis/hset conn "solar:planet:moon:charon"
+              {"planet" "pluto" "nick" "char" "age" "4.5 billion years" "mass" "1586000000000000000000"}))
 
 (deftest should-full-text-search-star
   (make-solar-system tt/conn)

--- a/test/obiwan/test/tools.clj
+++ b/test/obiwan/test/tools.clj
@@ -54,7 +54,7 @@
                   :redis
                   :server
                   :port)]
-         (redis/create-pool {:port port}))))
+         (redis/connect {:port port}))))
 
 (defn with-redis [f]
   (let [server (start-redis-server)]
@@ -66,7 +66,7 @@
 (defn with-connection-pool [f]
   (binding [conn (make-connection-pool)]
     (f)
-    (redis/close-pool conn)))
+    (redis/disconnect conn)))
 
 (defn with-flushall [f]
     (f)

--- a/test/obiwan/test/tools.clj
+++ b/test/obiwan/test/tools.clj
@@ -54,7 +54,8 @@
                   :redis
                   :server
                   :port)]
-         (redis/connect {:port port}))))
+         (redis/connect {:nodes [{:host "localhost"
+                                  :port port}]}))))
 
 (defn with-redis [f]
   (let [server (start-redis-server)]


### PR DESCRIPTION
## full refactor to support [UnifiedJedis](https://javadoc.io/static/redis.clients/jedis/5.0.0-beta2/redis/clients/jedis/UnifiedJedis.html)

which is a stepping stone to JedisCluster, JedisPooled, JedisSentineled, JedisSharding

a few braking changes (hence the minor version bump):

### connecting / disconnecting

pre `0.2.x`:
```clojure
=> (def conn (redis/create-pool))
=> (redis/close-pool conn)
```

`0.2.x` and later:

```clojure
=> (def conn (redis/connect))
=> (redis/disconnect conn)
```

### configuration params

some renames, some addtions, some regroupping:

```clojure
{:nodes                                  ;; [{:host "1.1.1.1" :port 6379} {:host "2.2.2.2" :port 6380}]
 :to                                     ;; :cluster, :sentinel
 :connection-timeout socket-timeout
 :max-attempts
 :username password
 :database-index
 :ssl?
 :client-name
 :master-name
 :sentinel-client-config                 ;; if not provided a default config will be created if sentinel is used
 :pool-size pool-max-wait pool-max-idle}
```

### pipelines

they are currently on Jedis and will have to be ported to UnifiedJedis<br/>
in this version they won't work