### PR TITLE
upgraded jedis version and introduced set-get function

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
 
- :deps {redis.clients/jedis {:mvn/version "5.0.0-beta2"}}
+ :deps {redis.clients/jedis {:mvn/version "6.0.0"}}
 
  :aliases {:dev {:extra-paths ["dev" "dev-resources"]
                  :extra-deps {metosin/jsonista {:mvn/version "0.3.3"}

--- a/src/obiwan/commands.clj
+++ b/src/obiwan/commands.clj
@@ -17,8 +17,7 @@
     ex (.ex ex)
     exat (.exAt exat)
     pxat (.pxAt pxat)
-    keepttl (.keepttl)
-    get (.get)))
+    keepttl (.keepttl)))
 
 (defn <-tuple
   "this fn transforms the data from redis tuple to clojure map"

--- a/src/obiwan/core.clj
+++ b/src/obiwan/core.clj
@@ -254,6 +254,13 @@
 (defn get [^UnifiedJedis redis k]
   (.get redis k))
 
+(defn setget
+  ([^UnifiedJedis redis k v]
+   (.setGet redis k v))
+  ([^UnifiedJedis redis k v params]
+   (let [ps (c/->set-params params)]
+     (.setGet redis k v ps))))
+
 (defn mset [^UnifiedJedis redis m]
   (.mset redis (t/m->array m)))
 

--- a/src/obiwan/core.clj
+++ b/src/obiwan/core.clj
@@ -254,7 +254,7 @@
 (defn get [^UnifiedJedis redis k]
   (.get redis k))
 
-(defn setget
+(defn set-get
   ([^UnifiedJedis redis k v]
    (.setGet redis k v))
   ([^UnifiedJedis redis k v params]


### PR DESCRIPTION
the changes include:
- updated the latest version of jedis
- added a new function `setget` that sets the value in redis cache and returns the previous value
- removed `get` from `->set-params` command that is no longer supported

**_test screenshots_**

<img width="774" height="332" alt="Screenshot from 2025-07-15 09-01-29" src="https://github.com/user-attachments/assets/583383b8-87c2-4459-83de-69e0eaaafcb5" />

**_test screenshot with ->set-params_**
this test is to add `nx` and validate to make sure that the initial value is not changed after caching and you will notice that after the initial value is set, it does not change no matter how many times we try.

<img width="898" height="364" alt="image" src="https://github.com/user-attachments/assets/e1453d8a-d110-451d-b5e4-d854459c5052" />
